### PR TITLE
Stop depending on the mssql package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-odata-sql",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Convert OData queries into SQL statements",
   "main": "src/index.js",
   "author": "Microsoft",
@@ -11,7 +11,6 @@
     "lint": "jshint src"
   },
   "dependencies": {
-    "mssql": "^3.2.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/src/format.js
+++ b/src/format.js
@@ -9,8 +9,7 @@ var types = require('./utilities/types'),
     convertTypes = require('./convertTypes'),
     booleanize = require('./booleanize'),
     helpers = require('./helpers'),
-    expressions = require('./expressions'),
-    mssql = require('mssql');
+    expressions = require('./expressions');
 
 function ctor(tableConfig) {
     this.tableConfig = tableConfig || {};
@@ -352,7 +351,7 @@ var SqlFormatter = types.deriveClass(ExpressionVisitor, ctor, {
             return expr;
         }
 
-        this.statement.sql += this._createParameter(expr.value, mssql.FLOAT);
+        this.statement.sql += this._createParameter(expr.value, 'float');
 
         return expr;
     },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,8 +3,7 @@
 // ----------------------------------------------------------------------------
 
 var types = require('./utilities/types'),
-    strings = require('./utilities/strings'),
-    mssql = require('mssql');
+    strings = require('./utilities/strings');
 
 var helpers = module.exports = {
     // Performs the following validations on the specified identifier:
@@ -77,26 +76,6 @@ var helpers = module.exports = {
                 return "DATETIMEOFFSET(7)";
             default:
                 throw new Error("Unable to map value " + value.toString() + " to a SQL type.");
-        }
-    },
-
-    getMssqlType: function (value, primaryKey) {
-        switch (value !== undefined && value !== null && value.constructor) {
-            case String:
-                return primaryKey ? mssql.NVarChar(255) : mssql.NVarChar();
-            case Number:
-                return primaryKey || isInteger(value) ? mssql.Int : mssql.Float;
-            case Boolean:
-                return mssql.Bit;
-            case Date:
-                return mssql.DateTimeOffset;
-            case Buffer:
-                return mssql.VarBinary;
-        }
-
-        function isInteger(value) {
-            // integers larger than the maximum value get inserted as 1 - treat these as float parameters as a workaround
-            return value.toFixed() === value.toString() && value < 2147483648 && value > -2147483648;
         }
     },
 

--- a/test/mssql.tests.js
+++ b/test/mssql.tests.js
@@ -2,8 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 var formatSql = require('../src/format'),
-    equal = require('assert').equal,
-    mssql = require('mssql');
+    equal = require('assert').equal;
 
 describe('azure-odata-sql.mssql', function () {
     it("preserves float parameters with zeroes", function () {
@@ -13,7 +12,7 @@ describe('azure-odata-sql.mssql', function () {
         },
             statements = formatSql(query, { schema: 'testapp'});
         equal(statements.length, 1);
-        equal(statements[0].parameters[1].type, mssql.FLOAT);
+        equal(statements[0].parameters[1].type, 'float');
     });
 
     it("correctly handles null take", function () {

--- a/test/sqlite.tests.js
+++ b/test/sqlite.tests.js
@@ -2,8 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 var formatSql = require('../src/format'),
-    equal = require('assert').equal,
-    mssql = require('mssql');
+    equal = require('assert').equal;
 
 describe('azure-odata-sql.sqlite', function () {
     it("preserves float parameters with zeroes", function () {
@@ -13,7 +12,7 @@ describe('azure-odata-sql.sqlite', function () {
         },
             statements = formatSql(query);
         equal(statements.length, 1);
-        equal(statements[0].parameters[1].type, mssql.FLOAT);
+        equal(statements[0].parameters[1].type, 'float');
     });
 
     it("correctly handles null take", function () {


### PR DESCRIPTION
- This package depended on mssql only for the mssql.Float datatype. This commit removes dependency on the mssql package as depending on mssql creates problems while bundling with webpack
- Changed the implementation of visitFloatConstant to specify type as a string instead of a mssql datatype
- Removed unused method getMssqlType in src/helpers.js
- This is a breaking change in behavior. Updated version to 1.0.0