### PR TITLE
Fix incorrect order of params in sqlite INSTR method

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -558,9 +558,9 @@ var SqlFormatter = types.deriveClass(ExpressionVisitor, ctor, {
         else if (functionName == 'indexof') {
             if (this.flavor === 'sqlite') {
                 this.statement.sql += "(INSTR(";
-                this.visit(args[0]);
-                this.statement.sql += ", ";
                 this.visit(instance);
+                this.statement.sql += ", ";
+                this.visit(args[0]);
                 this.statement.sql += ') - 1)';
             } else {
                 this.statement.sql += "(PATINDEX('%' + ";

--- a/test/sqlite.tests.js
+++ b/test/sqlite.tests.js
@@ -511,7 +511,7 @@ describe('azure-odata-sql.sqlite', function () {
             table: 'products',
             filters: "indexof(name, 'Abc') eq 5"
         };
-        var statements = verifySqlFormatting(query, "SELECT * FROM [products] WHERE ((INSTR(@p1, [name]) - 1) = @p2)");
+        var statements = verifySqlFormatting(query, "SELECT * FROM [products] WHERE ((INSTR([name], @p1) - 1) = @p2)");
         equal(statements.length, 1);
         equal(statements[0].parameters[0].value, 'Abc');
         equal(statements[0].parameters[1].value, 5);


### PR DESCRIPTION
As documented in https://www.sqlite.org/lang_corefunc.html.
Order of parameters for INSTR is reversed in compare to SQL PATINDEX analog.